### PR TITLE
task: Register RDS instance variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Manage RDS
   rds_engine: 'postgres'
   rds_engine_version: '9.5.4'
 ```
+
+The result of the `rds` resource will be stored in `manage_rds_{{ rds_name | replace('-', '_') }}": "{{result}}`. A `rds_name` of `foo-bar` would be set as `manage_rds_foo_bar`.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,3 +28,8 @@
       Stack: "{{ stack_rds_tag_stack | default(omit) }}"
       Layer: "{{ stack_rds_tag_layer | default(omit) }}"
       Context: "{{ rds_context | default(omit) }}"
+  register: result
+
+- name: Set RDS Fact
+  set_fact:
+    "manage_rds_{{ rds_name | replace('-', '_') }}": "{{result}}"


### PR DESCRIPTION
Register a variable so the results can be used in other plays. This removes
the need to copy paste or hardcode values that can be determined by ansible.