### PR TITLE
add KubernetesCluster tag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,4 +13,5 @@ rds_instance_type: 'db.t2.medium'
 rds_multi_zone: no
 rds_subnet_group: "{{ rds_context | default(rds_environment) }}-rds"
 
+k8s_cluster_tag_val: "{{ rds_environment }}"
 rds_debug: "{{ debug|default('False') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
     password:             "{{ rds_master_password | mandatory }}"
     tags:
       Env:   "{{ rds_environment }}"
+      KubernetesCluster:  "{{ k8s_cluster_tag_val }}"
       Stack: "{{ stack_rds_tag_stack | default(omit) }}"
       Layer: "{{ stack_rds_tag_layer | default(omit) }}"
       Context: "{{ rds_context | default(omit) }}"


### PR DESCRIPTION


Default value == rds_environment tag, but intended to be something specific .. i.e. match kops KubernetesCluster name

The use case is for datadog ... We only want to monitor assets who include a certain tag.